### PR TITLE
增加一个directQuery方法，可以返回List<Map<String,Object>>作为结果集

### DIFF
--- a/src/org/redkale/source/Transaction.java
+++ b/src/org/redkale/source/Transaction.java
@@ -1,0 +1,95 @@
+package org.redkale.source;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * 事务管理器
+ * @author wicks
+ */
+public class Transaction {
+	
+	private Connection connection = null;
+	private ResultSet resultSet = null;
+	private PreparedStatement statement = null;
+	
+	/**
+	 * 开启事务
+	 * @param conn
+	 * @throws SQLException 
+	 */
+	public void beigin(Connection conn) throws SQLException{
+		if(conn != null && connection == null){
+			connection = conn;
+			conn.setAutoCommit(false);
+		}
+	}
+	
+	/**
+	 * 查询
+	 * @param sql
+	 * @return
+	 * @throws SQLException
+	 */
+	public ResultSet query(String sql) throws SQLException{
+		closeResources();
+		statement = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+		return statement.executeQuery();
+	}
+	
+	/**
+	 * 执行
+	 * @param sql
+	 * @return
+	 * @throws SQLException
+	 */
+	public int execute(String sql) throws SQLException{
+		closeResources();
+		statement = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+		return statement.executeUpdate();
+	}
+	
+	/**
+	 * 提交事务
+	 * @param conn
+	 * @throws SQLException 
+	 */
+	public void commit() throws SQLException{
+		if(connection != null){
+			connection.commit();
+			connection.setAutoCommit(true);
+			closeResources();
+			connection.close();
+		}
+	}
+	
+	/**
+	 * 回滚事务
+	 * @param conn
+	 * @throws SQLException 
+	 */
+	public void rollback() throws SQLException{
+		if(connection != null){
+			connection.rollback();
+			connection.setAutoCommit(true);
+			closeResources();
+			connection.close();
+		}
+	}
+	
+	/**
+	 * 关闭共用资源
+	 * @throws SQLException
+	 */
+	private void closeResources() throws SQLException{
+		if(resultSet != null){
+			resultSet.close();
+		}
+		if(statement != null){
+			statement.close();
+		}
+	}
+
+}


### PR DESCRIPTION
redkale作者你好，我一直很喜欢redkale这种轻量级的框架。在使用中，我发现directQuery方法查询出的ResultSet作为下一个sql查询条件时很不方便，所以希望能够添加一个返回List<Map<String,Object>>的方法，希望能够采纳
另外一方面，当想要执行多条SQL语句，中间出现问题想回滚时，缺少事务的支持，所以增加了一个可以回滚的事务类，可以这么用
transactionManger.beigin(ds.createWriteSQLConnection());
transactionManger.commit();
transactionManger.rollback();
